### PR TITLE
Add -P provider option with GitLab as default v0.9.7 - prepare Other provider eg: github...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to git-remote-forge are documented here.
 
+## [0.9.7] - 2026-01-XX
+
+### Added
+- `-P` flag for provider selection (gitlab|github|bitbucket|gitea, default: gitlab)
+- Provider validation with error handling for invalid provider values
+- Case-insensitive provider value matching
+
+### Changed
+- Provider option now accepts command-line argument (prepares for multi-provider support)
+- Default provider remains GitLab when `-P` is not specified
+
+### Note
+- Currently only GitLab provider is fully functional
+- GitHub, Bitbucket, and Gitea providers are in development
+
+---
+
 ## [0.9.6] - 2026-01-XX
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ gitremote -d my-project -n myusername -f
   - Example: `-T "python,django,postgresql"`
 - `-t` : Auto-detect technologies from existing files (flag, no argument)
 
-### Provider Options
+### Provider Options (TODO)
 
 - `-S` : Self-hosted URL (optional, for self-hosted GitLab instances)
   - Example: `-S gitlab.example.com`
@@ -374,3 +374,32 @@ Make sure git is configured:
 git config --global user.name "Your Name"
 git config --global user.email "your.email@example.com"
 ```
+
+### Tips
+
+Create aliases in your profile:
+
+I plan to add feature to use a config fileso that your prefered Provider and namespace are always set.
+until then, easiest way is to add export and aliases in your shell profile
+
+```bash
+# ===== GIT REMOTE FORGE =====
+# gitremoteforge - default Values
+export GITREMOTE_FORGE_NAMESPACE="my_gitlab_group"
+# export GITREMOTE_FORGE_PROVIDER="gitlab"
+
+# Create New Git repo from current directory
+alias grfcurrent='gitremote -n ${GITREMOTE_FORGE_NAMESPACE} -i -f'
+
+# Create New Git repo and new directory in current directory requires directory name as argument
+alias grfnew='gitremote -n ${GITREMOTE_FORGE_NAMESPACE} -i -d $1'
+
+```
+
+Now,
+
+1. Head into your Projects directory,
+   - type `grfnew my_new_repo` to create a New local directory and push it to your favorite Provider and namespace.
+
+2. Head into an existing Project directory with no .git initiated ( eg you use mkdir -p or created it in your Finder),
+   - type `grfcurrent` to create a New git repo in current local directory and push it to your favorite Provider and namespace.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool to create and setup git projects locally and push them remotely on GitLab
 
 ## Status
 
-**v0.9.6 - Ready for Use (GitLab Only)**
+**v0.9.7 - Ready for Use (GitLab Only)**
 
 git-remote-forge has reached a stable state suitable for production use.
 The core workflow is tested and reliable: create local repositories, initialize branches by default (main, develop, production) locally, then push to GitLab with a single command.
@@ -239,7 +239,13 @@ gitremote -d my-project -n myusername -f
   - Example: `-T "python,django,postgresql"`
 - `-t` : Auto-detect technologies from existing files (flag, no argument)
 
-### Provider Options (TODO)
+### Provider Options
+
+- `-P` : Provider selection (gitlab|github|bitbucket|gitea, default: gitlab)
+  - **Note: Currently only GitLab is fully supported. Other providers (github, bitbucket, gitea) are in development.**
+  - Example: `-P gitlab` (explicitly set provider to GitLab)
+  - When not specified, defaults to GitLab
+  - Invalid provider values will show an error and exit
 
 - `-S` : Self-hosted URL (optional, for self-hosted GitLab instances)
   - Example: `-S gitlab.example.com`
@@ -292,6 +298,9 @@ gitremote -d my-project -n myusername -r gitlab
 
 # Use existing directory with auto-detect technologies
 gitremote -n myusername -p /path/to/project -t
+
+# Explicitly specify provider (GitLab - currently only supported provider)
+gitremote -d my-project -n myusername -P gitlab
 
 # Force mode (skip confirmation)
 gitremote -d my-project -n myusername -f

--- a/TODOs.md
+++ b/TODOs.md
@@ -15,7 +15,7 @@
 -d, --dir          Project directory/name (required for new repo)
 -c, --current      Project directory/name (required for new repo) from current Directory. ( no -d), same as -p
 -n, --namespace    Namespace/username (target on provider)
-# -P, --repo-provider Provider: (gitlab|github|bitbucket|gitea) (default: gitlab)
+-P, --provider     Provider: (gitlab|github|bitbucket|gitea) (default: gitlab) # ✅ COMPLETE (v0.9.7)
 -S, --self-hosted  Self-hosted URL (optional, for self-hosted instances gitlab|gitea)
 -t                 Auto-detect technologies (existing directory mode only)
 -T, --tech         Technologies (user-provided, comma-separated, optional)
@@ -101,6 +101,7 @@
 - [x] `-R` Replace remote URL (prompts for confirmation if URL differs) # ✅ COMPLETE (v0.9.5)
 - [x] URL duplicate detection - prevent adding multiple remotes with same URL # ✅ COMPLETE (v0.9.5)
 - [x] Fix no-args behavior: display help/usage instead of prompting to create repo # ✅ COMPLETE (v0.9.6)
+- [x] `-P` Provider selection option (gitlab|github|bitbucket|gitea, default: gitlab) # ✅ COMPLETE (v0.9.7)
 
 ---
 

--- a/gitremote.sh
+++ b/gitremote.sh
@@ -7,7 +7,7 @@
 #   - production: for production releases
 #   - develop: active development branch
 
-Version="0.9.6"
+Version="0.9.7"
 
 # Prerequisites:
 # - Git configured locally (user.name and user.email)
@@ -74,6 +74,7 @@ usage() {
     echo "  -T    Technologies (user-provided, comma-separated, optional)"
     echo "  -b    Branch to checkout after creation (default: develop)"
     echo "  -p    Path to local directory (optional, for existing directory mode)"
+    echo "  -P    Provider (gitlab|github|bitbucket|gitea, default: gitlab)"
     echo "  -f    Force mode (skip dry-run and confirmation)"
     echo "  -O    Override existing .git directory (removes and reinitializes) - DESTRUCTIVE - Requires double confirmations even with -f flag"
     echo "  -h    Display this help message"
@@ -92,8 +93,8 @@ usage() {
 # Parse command line arguments
 # Handles all command-line flags and sets corresponding variables
 parse_arguments() {
-    # Current flags: d, n, t, T, B, S, p, r, R, i, O, f, h
-    while getopts "d:n:t:T:b:S:p:r:R:iOfh" opt; do
+    # Current flags: d, n, t, T, B, S, p, r, R, i, O, f, h, P
+    while getopts "d:n:t:T:b:S:p:r:R:iOfhP:" opt; do
         case ${opt} in
             d )
                 # Directory/Project name (creates new directory)
@@ -148,6 +149,23 @@ parse_arguments() {
                 # WARNING: This is a destructive operation that removes all branches and remotes
                 # ALWAYS requires two-step confirmation (even with -f flag) for safety
                 OVERRIDE_GIT=true
+                ;;
+            P )
+                # -P flag: Provider selection (gitlab|github|bitbucket|gitea)
+                # Sets the git provider to use for remote repository setup
+                # Default: gitlab (set at script initialization)
+                # Validates provider value and exits with error if invalid
+                local provider_value=$(echo "$OPTARG" | tr '[:upper:]' '[:lower:]')
+                case "$provider_value" in
+                    gitlab|github|bitbucket|gitea)
+                        PROVIDER="$provider_value"
+                        ;;
+                    *)
+                        echo "Error: Invalid provider '$OPTARG'. Supported providers: gitlab, github, bitbucket, gitea"
+                        usage
+                        exit 1
+                        ;;
+                esac
                 ;;
             : )
                 # Missing argument for option
@@ -694,7 +712,9 @@ setup_provider() {
             exit 1
             ;;
         gitea)
-            handle_gitea_setup "$target" "$self_hosted_url"
+            # TODO: handle_gitea_setup "$target" "$self_hosted_url"
+            echo "Error: Bitbucket support coming soon"
+            exit 1
             ;;
         *)
             echo "Error: Unknown provider: $provider"

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # A Bash script to install gitremote.sh.
 # Will be installed in /usr/local/bin/gitremote
 
-VERSION="0.9.6"
+VERSION="0.9.7"
 INSTALL_PATH="/usr/local/bin/gitremote"
 SCRIPT_SOURCE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gitremote.sh"
 


### PR DESCRIPTION
- Add -P flag for provider selection (gitlab|github|bitbucket|gitea)
- Default provider remains GitLab when -P is not specified
- Validate provider values with case-insensitive matching
- Update version to 0.9.7 in all files
- Document -P option in README.md (note: only GitLab currently supported)
- Update CHANGELOG.md and TODOs.md with new feature

This prepares the codebase for future multi-provider support while
maintaining backward compatibility with GitLab as the default provider.